### PR TITLE
feat: support file uploads

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,9 @@
 import os
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from .routes import content, playlists, displays, settings
+from fastapi.staticfiles import StaticFiles
+from .routes import content, playlists, displays, settings, uploads
+from .routes.uploads import UPLOAD_DIR
 from .db import Base, engine
 
 Base.metadata.create_all(bind=engine)
@@ -21,6 +23,9 @@ app.include_router(content.router)
 app.include_router(playlists.router)
 app.include_router(displays.router)
 app.include_router(settings.router)
+app.include_router(uploads.router)
+
+app.mount("/uploads", StaticFiles(directory=UPLOAD_DIR), name="uploads")
 
 @app.get("/health")
 def health():

--- a/backend/app/routes/uploads.py
+++ b/backend/app/routes/uploads.py
@@ -1,0 +1,18 @@
+import uuid
+from pathlib import Path
+from fastapi import APIRouter, UploadFile, File, Request
+from .. import schemas
+
+UPLOAD_DIR = Path(__file__).resolve().parent.parent / "uploaded_files"
+UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
+
+router = APIRouter(prefix="/api", tags=["uploads"])
+
+@router.post("/upload", response_model=schemas.FileUploadResponse)
+async def upload_file(request: Request, file: UploadFile = File(...)):
+    ext = Path(file.filename).suffix
+    filename = f"{uuid.uuid4()}{ext}"
+    filepath = UPLOAD_DIR / filename
+    with open(filepath, "wb") as buffer:
+        buffer.write(await file.read())
+    return {"file_url": f"{request.base_url}uploads/{filename}"}

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -117,3 +117,7 @@ class DisplaySettingsUpdate(DisplaySettingsBase): pass
 class DisplaySettings(DisplaySettingsBase):
     id: str
     class Config: from_attributes = True
+
+# ---- File Upload ----
+class FileUploadResponse(BaseModel):
+    file_url: str


### PR DESCRIPTION
## Summary
- add `/api/upload` route for file uploads
- serve uploaded files statically and expose upload directory
- add schema for upload responses

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689775b1c9688331aef96c89fbfe6943