### PR TITLE
Enable playlist creation across UI

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -76,8 +76,11 @@ class Playlist(BaseModel):
     is_active: bool
     loop: bool
     transition_effect: str
-    items: list[PlaylistItem] = []
-    class Config: from_attributes = True
+    content_items: list[PlaylistItem] = Field(default_factory=list, alias="items")
+
+    class Config:
+        from_attributes = True
+        populate_by_name = True
 
 # ---- Display ----
 class DisplayBase(BaseModel):

--- a/frontend/src/api/entities.js
+++ b/frontend/src/api/entities.js
@@ -14,7 +14,10 @@ export const ContentItem = {
 };
 
 export const Playlist = {
-  list: (params) => playlistsApi.list(params),
+  list: (paramsOrOrder) => {
+    const params = typeof paramsOrOrder === "object" ? paramsOrOrder : {};
+    return playlistsApi.list(params);
+  },
   filter: async (params = {}) => {
     if (params.id) {
       const pl = await playlistsApi.get(params.id);


### PR DESCRIPTION
## Summary
- Return playlist items under `content_items` in API responses
- Allow playlist listing helper to handle sort strings

## Testing
- `pytest`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68977c106aec8331884914beb54ad54a