### PR TITLE
Make Create Content button submit form

### DIFF
--- a/frontend/src/pages/Upload.jsx
+++ b/frontend/src/pages/Upload.jsx
@@ -643,8 +643,7 @@ export default function Upload() {
                   Cancel
                 </Button>
                 <Button
-                  type="button"
-                  onClick={handleSubmit}
+                  type="submit"
                   disabled={isUploading || (!uploadedFiles.length && !urlContent && !textContent)}
                   className="bg-orange-500 hover:bg-orange-600 text-white border-none shadow-lg"
                 >


### PR DESCRIPTION
## Summary
- Make the "Create Content" button on Upload page submit its surrounding form
- Keep existing `onSubmit={handleSubmit}` so clicking the button or pressing Enter invokes the handler

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 389 errors, 10 warnings)*

------
https://chatgpt.com/codex/tasks/task_b_68978eada69083319d77ddccef62ab4d